### PR TITLE
Use files instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-ios/
-android/
-yarn.lock
-.flowconfig
-.buckconfig
-.gitattributes
-.watchmanconfig

--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
       "name": "rmercille"
     }
   ],
+  "files": [
+    "src/",
+    "app.json",
+    "config.json",
+    "index.android.js",
+    "index.ios.js"
+  ],
+  "main": "index.js",
   "version": "0.0.1",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Quick change that removes `.npmignore` and replaces it with _selectively including_ files using the `files` field in `package.json`.
With the previously used .npmignore file, several files (e.g. everything in `.vscode/`, `.idea/`, **3.9 MB of readme images**, etc) would end up in the archive! Also, it included a redundant entry for `yarn.lock` (which is excluded by default).

The new archive is now only 170KB (instead of 4.1MB).