### PR TITLE
Enable basic GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: main
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn
+      - name: Lint code
+        run: yarn lint

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "flow": "flow",
-    "lint": "standard '**/*.js'",
+    "lint": "standard 'src/**/*.js'",
     "precommit": "npm run lint && npm test && npm docs",
     "test": "jest"
   },


### PR DESCRIPTION
This adds a workflow config for a minimal React Native CI (currently just running `lint`) using [GitHub Actions](https://github.com/features/actions). It does two runs on both Node 10.x and 12.x (current and previous LTS releases).