### PR TITLE
Simplify contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,30 +3,14 @@
   "homepage": "https://electrode.io",
   "author": "The Electrode Native Team",
   "contributors": [
-    {
-      "name": "a♯b♭"
-    },
-    {
-      "name": "belemaire"
-    },
-    {
-      "name": "deepueg"
-    },
-    {
-      "name": "friederbluemle"
-    },
-    {
-      "name": "gmbharath12"
-    },
-    {
-      "name": "krunalsshah"
-    },
-    {
-      "name": "lianci"
-    },
-    {
-      "name": "rmercille"
-    }
+    "a♯b♭",
+    "belemaire",
+    "deepueg",
+    "friederbluemle",
+    "gmbharath12",
+    "krunalsshah",
+    "lianci",
+    "rmercille"
   ],
   "files": [
     "src/",

--- a/src/views/about/about.js
+++ b/src/views/about/about.js
@@ -57,11 +57,6 @@ export default class About extends Component {
   }
 
   render() {
-    const renderedContributors =
-      contributors &&
-      contributors.map(
-        person => `${person.name}${person.email ? ` (${person.email})` : ''}`,
-      );
     const Highlight = ({children}) => (
       <Text style={styles.highlight}>{children}</Text>
     );
@@ -80,7 +75,7 @@ export default class About extends Component {
             <Section title="Who...">
               <SubSection>
                 <Question>Contributed to this project?</Question>
-                <Paragraph>{renderedContributors.join(', ')}</Paragraph>
+                <Paragraph>{contributors.join(', ')}</Paragraph>
               </SubSection>
               <SubSection>
                 <Question>Should look at this project?</Question>


### PR DESCRIPTION
Using simple strings for the `contributors` instead of full objects saves a bunch of lines in `package.json`, and allows for a minor simplification in `about.js`.

Docs on [people fields in package.json](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)